### PR TITLE
fix: update UserRepository primary key type and remove unused UserDetails overrides

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/model/User.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/model/User.java
@@ -45,25 +45,5 @@ public class User implements UserDetails {
     public String getUsername() {
         return email;
     }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return UserDetails.super.isAccountNonExpired();
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return UserDetails.super.isAccountNonLocked();
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return UserDetails.super.isCredentialsNonExpired();
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return UserDetails.super.isEnabled();
-    }
 }
 

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/repository/UserRepository.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/repository/UserRepository.java
@@ -5,9 +5,10 @@ import com.jcluna.auth_api.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
 
 }


### PR DESCRIPTION
UserRepository primary key type mismatch (Integer - UUID).
Remove unused UserDetails override methods from User entity and fix 

Changes:
- UserRepository: JpaRepository<User, UUID> to match entity and DB schema
- User entity: removed isAccountNonExpired, isAccountNonLocked, 
  isCredentialsNonExpired and isEnabled overrides, redundant with 
  UserDetails interface defaults return true