### PR TITLE
feat: add Signature persistence layer

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/QuoteController.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/QuoteController.java
@@ -25,7 +25,7 @@ public class QuoteController {
     }
 
     @GetMapping("/random")
-    public ResponseEntity<QuoteResponse> getRandomQuote() {
+    public ResponseEntity<QuoteResponse> Rote() {
         return ResponseEntity.ok(quoteService.getRandomQuote());
     }
 

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureRequest.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureRequest.java
@@ -1,0 +1,19 @@
+package com.jcluna.auth_api.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignatureRequest {
+    @NotBlank(message = "No has insertado texto")
+    private String signature;
+    @NotBlank(message = "Se necesita un nombre para la firma")
+    private String author;
+}

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureResponse.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureResponse.java
@@ -1,0 +1,12 @@
+package com.jcluna.auth_api.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignatureResponse {
+    private String signature;
+    private String author;
+}

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/exception/GlobalExceptionHandler.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(errors);
     }
 
+    // UserAlreadyExist
     @ExceptionHandler(UserAlreadyExistException.class)
     public ResponseEntity<Map<String, String>> handleUserAlreadyExists(UserAlreadyExistException ex) {
         Map<String, String> error = new HashMap<>();
@@ -31,6 +32,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
     }
 
+    // InvalidCredentials
     @ExceptionHandler(InvalidCredentialsException.class)
     public ResponseEntity<Map<String, String>> handleInvalidCredentials(InvalidCredentialsException ex) {
         Map<String, String> error = new HashMap<>();
@@ -38,6 +40,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
     }
 
+    // QuoteNotFound
     @ExceptionHandler(QuoteNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleQuoteNotFound(QuoteNotFoundException ex) {
         Map<String, String> error = new HashMap<>();
@@ -47,6 +50,7 @@ public class GlobalExceptionHandler {
 
 
 
+    //500
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleGenericException(Exception ex) {
         Map<String, String> error = new HashMap<>();

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/model/Signature.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/model/Signature.java
@@ -1,0 +1,35 @@
+package com.jcluna.auth_api.model;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "signatures")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Signature {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    @Column (name = "message")
+    private String signature;
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    @Column
+    private String author;
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+}

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/repository/SignatureRepository.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/repository/SignatureRepository.java
@@ -1,0 +1,19 @@
+package com.jcluna.auth_api.repository;
+
+
+import com.jcluna.auth_api.model.Signature;
+import com.jcluna.auth_api.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SignatureRepository extends JpaRepository<Signature, UUID> {
+
+    Optional<Signature> findByUser(User user);
+
+
+
+}

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/security/SecurityConfig.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**","/error").permitAll()
-                        .requestMatchers("/quotes/random", "/quotes/all", "/quotes/search").hasAnyRole("GUEST", "ADMIN")
+                        .requestMatchers("/quotes/random", "/quotes/all", "/quotes/search").hasAnyRole("GUEST","USER", "ADMIN")
                         .requestMatchers("/quotes/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/QuoteService.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/QuoteService.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 public interface QuoteService {
 
-
+    // Get a random quote to show in the dashboard after login
     QuoteResponse getRandomQuote();
     Page<QuoteResponse> getAllQuotes(Pageable pageable);
     Page<QuoteResponse> searchByAuthor(String author, Pageable pageable);

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/QuoteServiceImpl.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/QuoteServiceImpl.java
@@ -8,6 +8,7 @@ import com.jcluna.auth_api.model.Quote;
 import com.jcluna.auth_api.model.User;
 import com.jcluna.auth_api.repository.QuoteRepository;
 import com.jcluna.auth_api.service.QuoteService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,15 +19,10 @@ import java.util.UUID;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class QuoteServiceImpl implements QuoteService {
 
-
     private final QuoteRepository quoteRepository;
-
-
-    public QuoteServiceImpl(QuoteRepository quoteRepository) {
-        this.quoteRepository = quoteRepository;
-    }
 
 
     @Override
@@ -79,7 +75,6 @@ public class QuoteServiceImpl implements QuoteService {
 
     // Returns 404 for both "not found" and "not owned" cases intentionally.
     // Avoids confirming resource existence to unauthorized users.
-
     @Override
     public QuoteResponse updateQuote(UUID id, QuoteRequest request, User user) {
         Quote quote = quoteRepository.findByIdAndUser(id, user)

--- a/backend/auth-api/src/main/resources/db/migration/V7__create_table_signature.sql
+++ b/backend/auth-api/src/main/resources/db/migration/V7__create_table_signature.sql
@@ -1,0 +1,9 @@
+ALTER TABLE signatures
+    RENAME COLUMN date TO created_at;
+
+ALTER TABLE signatures
+    ADD COLUMN author     VARCHAR(100) NOT NULL DEFAULT 'Anonymous',
+    ADD COLUMN updated_at TIMESTAMP    NOT NULL DEFAULT now();
+
+ALTER TABLE signatures
+    ADD CONSTRAINT signatures_user_id_unique UNIQUE (user_id);


### PR DESCRIPTION
Add persistence layer for the Signature domain.

## Changes
- Flyway migration for `signatures` table
- Signature entity with User relationship
- `SignatureRepository` extending JpaRepository
- `SignatureRequest` and `SignatureResponse` DTOs