### PR TITLE
feat: implement Signature controller

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/AuthApiApplication.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/AuthApiApplication.java
@@ -2,8 +2,10 @@ package com.jcluna.auth_api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class AuthApiApplication {
 
 	public static void main(String[] args) {

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/QuoteController.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/QuoteController.java
@@ -29,7 +29,7 @@ public class QuoteController {
         return ResponseEntity.ok(quoteService.getRandomQuote());
     }
 
-    @GetMapping("/all")
+    @GetMapping("")
     public ResponseEntity<Page<QuoteResponse>> getAllQuotes(Pageable pageable) {
         return ResponseEntity.ok(quoteService.getAllQuotes(pageable));
     }

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/SignatureController.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/SignatureController.java
@@ -1,0 +1,62 @@
+package com.jcluna.auth_api.controller;
+
+
+import com.jcluna.auth_api.dto.SignatureRequest;
+import com.jcluna.auth_api.dto.SignatureResponse;
+import com.jcluna.auth_api.model.User;
+import com.jcluna.auth_api.service.SignatureService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/signature")
+@RequiredArgsConstructor
+public class SignatureController {
+
+    private final SignatureService signatureService;
+
+
+    @GetMapping("/me")
+    public ResponseEntity<SignatureResponse> getSignature(
+        @AuthenticationPrincipal User user){
+        return ResponseEntity.ok(signatureService.getMySignature(user));
+    }
+
+    @PostMapping()
+    public ResponseEntity<SignatureResponse> addSignature(
+            @Valid @RequestBody SignatureRequest request,
+            @AuthenticationPrincipal User user){
+        return ResponseEntity.status(HttpStatus.CREATED).body(signatureService.addMySignature(request, user));
+    }
+
+    @PutMapping()
+    public ResponseEntity<SignatureResponse> updateSignature(
+            @Valid @RequestBody SignatureRequest request,
+            @AuthenticationPrincipal User user){
+        return ResponseEntity.ok(signatureService.updateMySignature(request, user));
+    }
+
+
+    @DeleteMapping()
+    public ResponseEntity<Void> deleteSignature(
+            @AuthenticationPrincipal User user){
+        signatureService.deleteMySignature(user);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping()
+    public ResponseEntity<Page<SignatureResponse>> getAllSignature(Pageable pageable){
+        return ResponseEntity.ok(signatureService.getAllSignature(pageable));
+    }
+
+
+
+
+}

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureRequest.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureRequest.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class SignatureRequest {
     @NotBlank(message = "No has insertado texto")
-    private String signature;
+    private String message;
     @NotBlank(message = "Se necesita un nombre para la firma")
     private String author;
 }

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureResponse.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/SignatureResponse.java
@@ -4,9 +4,16 @@ package com.jcluna.auth_api.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.Instant;
+import java.util.UUID;
+
 @Getter
 @AllArgsConstructor
 public class SignatureResponse {
-    private String signature;
+    private String message;
     private String author;
+    private UUID id;
+    private Instant createdAt;
+    private Instant updatedAt;
+
 }

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/exception/GlobalExceptionHandler.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/exception/GlobalExceptionHandler.java
@@ -56,6 +56,7 @@ public class GlobalExceptionHandler {
     }
 
     // SignatureNotFound
+    @ExceptionHandler
     public ResponseEntity<Map<String, String>> handleSignatureNotFound(SignatureNotFoundException ex) {
         Map<String, String> error = new HashMap<>();
         error.put("error", ex.getMessage());

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/model/Signature.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/model/Signature.java
@@ -20,16 +20,16 @@ public class Signature {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
-    @Column (name = "message")
-    private String signature;
-    @Column(name = "created_at", updatable = false)
+    @Column
+    private String message;
+    @Column(insertable = false, updatable = false)
     private Instant createdAt;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
     @Column
     private String author;
-    @Column(name = "updated_at")
+    @Column(insertable = false, updatable = false)
     private Instant updatedAt;
 
 }

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/security/SecurityConfig.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -42,8 +43,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**","/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/signature").permitAll()
                         .requestMatchers("/quotes/random", "/quotes/all", "/quotes/search").hasAnyRole("GUEST","USER", "ADMIN")
-                        .requestMatchers("/quotes/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/quotes/**", "/signature/**").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/SignatureService.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/SignatureService.java
@@ -12,7 +12,7 @@ public interface SignatureService {
     // Get the user's signature after login to show it in the dashboard if it exists
     SignatureResponse getMySignature(User user);
 
-    SignatureResponse createMySignature(SignatureRequest request, User user);
+    SignatureResponse addMySignature(SignatureRequest request, User user);
 
     SignatureResponse updateMySignature(SignatureRequest request, User user);
 

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/SignatureServiceImpl.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/SignatureServiceImpl.java
@@ -26,33 +26,41 @@ public class SignatureServiceImpl implements SignatureService {
     public SignatureResponse getMySignature(User user) {
         Signature signature = signatureRepository.findByUser(user)
                 .orElseThrow(() -> {
-                    log.error("Signature not found for user: {}", user.getId());
+                    log.warn("Signature not found for user: {}", user.getId());
                     return new SignatureNotFoundException("No se ha encontrado ninguna firma");
                 });
 
 
         return new SignatureResponse(
-                signature.getSignature(),
-                signature.getAuthor()
-        );
+                signature.getMessage(),
+                signature.getAuthor(),
+                signature.getId(),
+                signature.getCreatedAt(),
+                signature.getUpdatedAt());
+
     }
 
     @Override
-    public SignatureResponse createMySignature(SignatureRequest request, User user) {
+    public SignatureResponse addMySignature(SignatureRequest request, User user) {
         signatureRepository.findByUser(user)
                 .ifPresent(s -> {
-                    log.error("Signature already exist");
+                    log.warn("Signature already exist: {}", user.getId());
                     throw new SignatureAlreadyExistException("Ya tienes una firma");
                 });
 
         Signature signature = new Signature();
-        signature.setSignature(request.getSignature());
+        signature.setMessage(request.getMessage());
         signature.setAuthor(request.getAuthor());
         signature.setUser(user);
 
         Signature saved = signatureRepository.save(signature);
 
-        return new SignatureResponse(saved.getSignature(), saved.getAuthor());
+        return new SignatureResponse(
+                saved.getMessage(),
+                saved.getAuthor(),
+                saved.getId(),
+                saved.getCreatedAt(),
+                saved.getUpdatedAt());
     }
 
 
@@ -61,24 +69,28 @@ public class SignatureServiceImpl implements SignatureService {
         Signature signature = signatureRepository.findByUser(user)
 
                 .orElseThrow(() -> {
-                    log.error("Signature not found on update for user: {}", user.getId());
+                    log.warn("Signature not found on update for user: {}", user.getId());
                     return new SignatureNotFoundException("No se ha encontrado ninguna firma");
                 });
 
-        signature.setSignature(request.getSignature());
+        signature.setMessage(request.getMessage());
         signature.setAuthor(request.getAuthor());
 
         Signature saved = signatureRepository.save(signature);
 
-        return new SignatureResponse(saved.getSignature(), saved.getAuthor());
-
+        return new SignatureResponse(
+                saved.getMessage(),
+                saved.getAuthor(),
+                saved.getId(),
+                saved.getCreatedAt(),
+                saved.getUpdatedAt());
     }
 
     @Override
     public void deleteMySignature(User user) {
         Signature signature = signatureRepository.findByUser(user)
                 .orElseThrow(() -> {
-                    log.error("Signature not found on delete for user: {}", user.getId());
+                    log.warn("Signature not found on delete for user: {}", user.getId());
                     return new SignatureNotFoundException("No se ha encontrado ninguna firma");
                 });
 
@@ -90,7 +102,12 @@ public class SignatureServiceImpl implements SignatureService {
     @Override
     public Page<SignatureResponse> getAllSignature(Pageable pageable) {
         Page<Signature> signatures = signatureRepository.findAll(pageable);
-        return signatures.map(signature -> new SignatureResponse(signature.getSignature(), signature.getAuthor()));
+        return signatures.map(signature -> new SignatureResponse(
+                signature.getMessage(),
+                signature.getAuthor(),
+                signature.getId(),
+                signature.getCreatedAt(),
+                signature.getUpdatedAt()));
     }
 
 

--- a/backend/auth-api/src/main/resources/db/migration/V8__add_updated_at_trigger_to_signatures.sql
+++ b/backend/auth-api/src/main/resources/db/migration/V8__add_updated_at_trigger_to_signatures.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON signatures
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
Expose Signature service methods through REST endpoints.

## Changes
- `SignatureController` with full CRUD endpoints
- Pagination support for `getAllSignatures`
- HTTP status codes (`201`, `200`, `204`)
- `@EnableSpringDataWebSupport` with `VIA_DTO` for stable pagination serialization
- Flyway migration for `updated_at` trigger