### PR TITLE
refactor: replace String role with Role enum

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/model/User.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/model/User.java
@@ -1,5 +1,6 @@
 package com.jcluna.auth_api.model;
 
+import com.jcluna.auth_api.model.enums.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,7 +32,11 @@ public class User implements UserDetails {   // Entity + Security Model through 
     private String userName;
     @Column(nullable = false)
     private String password;
-    private String role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     @Column(insertable = false, updatable = false)
     private Instant createdAt;
 
@@ -39,7 +44,7 @@ public class User implements UserDetails {   // Entity + Security Model through 
     // Define the users permissions.
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role));
+        return List.of(new SimpleGrantedAuthority(role.name()));
     }
 
     // Assign email as a getUsername

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/model/enums/Role.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/model/enums/Role.java
@@ -1,0 +1,7 @@
+package com.jcluna.auth_api.model.enums;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN,
+    ROLE_GUEST
+}

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/AuthServiceImpl.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/AuthServiceImpl.java
@@ -6,6 +6,7 @@ import com.jcluna.auth_api.dto.RegisterRequest;
 import com.jcluna.auth_api.exception.InvalidCredentialsException;
 import com.jcluna.auth_api.exception.UserAlreadyExistException;
 import com.jcluna.auth_api.model.User;
+import com.jcluna.auth_api.model.enums.Role;
 import com.jcluna.auth_api.repository.UserRepository;
 import com.jcluna.auth_api.security.JwtService;
 import com.jcluna.auth_api.service.AuthService;
@@ -44,7 +45,7 @@ public class AuthServiceImpl implements AuthService {
 
 
         // Role assigned server-side only. Never trust client input for role assignment (OWASP A01:2025 - Broken Access Control)
-        newUser.setRole("ROLE_USER");
+        newUser.setRole(Role.ROLE_USER);
 
         userRepository.save(newUser);
 


### PR DESCRIPTION
Replace String role field in User entity with Role enum (ROLE_USER, ROLE_ADMIN, ROLE_GUEST).

### Changes:
- Create Role enum in model/enums with EnumType.STRING persistence
- Refactor User entity: String role --> Role role
- Update getAuthorities() to use role.name()
- Update AuthServiceImpl: hardcoded string --> Role.ROLE_USER
