### PR TITLE
test: security integration tests for JWT filter and role-based access control

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/security/JwtAuthFilter.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/security/JwtAuthFilter.java
@@ -1,5 +1,7 @@
 package com.jcluna.auth_api.security;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,32 +34,37 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String authHeader = request.getHeader("Authorization");
+        try {
+            String authHeader = request.getHeader("Authorization");
 
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            // No token provided. Let the request pass — Spring Security will decide based on the endpoint rules.
-            filterChain.doFilter(request, response);
-            return;
-        }
-        String token = authHeader.substring(7);
-
-        // Extract email from token to identify the user.
-        String email = jwtService.extractEmail(token);
-
-        // Authenticate only if the user is not already authenticated in this request.
-        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-
-            if (jwtService.validateToken(token, email)) {
-                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities()
-                );
-                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authToken);
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                // No token provided. Let the request pass — Spring Security will decide based on the endpoint rules.
+                filterChain.doFilter(request, response);
+                return;
             }
-        }
+            String token = authHeader.substring(7);
 
-        filterChain.doFilter(request, response);
+            // Extract email from token to identify the user.
+            String email = jwtService.extractEmail(token);
+
+            // Authenticate only if the user is not already authenticated in this request.
+            if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+                if (jwtService.validateToken(token, email)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()
+                    );
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+
+            filterChain.doFilter(request, response);
+        }
+        catch (MalformedJwtException | ExpiredJwtException ex) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "No autorizado");
+        }
     }
 
 

--- a/backend/auth-api/src/test/java/com/jcluna/auth_api/security/JwtFilterSecurityTest.java
+++ b/backend/auth-api/src/test/java/com/jcluna/auth_api/security/JwtFilterSecurityTest.java
@@ -1,0 +1,61 @@
+package com.jcluna.auth_api.security;
+
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Date;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class JwtFilterSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    // Method to generate expired tokens
+    private String generateExpiredToken() {
+        return Jwts.builder()
+                .subject("test@test.com")
+                .issuedAt(new Date(System.currentTimeMillis() - 10000))
+                .expiration(new Date(System.currentTimeMillis() - 5000))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode("dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLXB1cnBvc2VzLW9ubHktMzJjaGFycw==")))
+                .compact();
+    }
+
+
+
+    // Test 1
+    @Test
+    void request_withoutToken_shouldReturn401() throws Exception {
+        mockMvc.perform(get("/quotes/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+
+    // Test 2
+    @Test
+    void request_withMalformedToken_shouldReturn401() throws Exception {
+        mockMvc.perform(get("/quotes/me")
+                        .header("Authorization", "Bearer tokenbasura"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // Test 3
+    @Test
+    void request_withExpiredToken_shouldReturn401() throws Exception {
+        mockMvc.perform(get("/quotes/me")
+                        .header("Authorization", "Bearer " + generateExpiredToken()))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/auth-api/src/test/java/com/jcluna/auth_api/security/RoleAccessControlTest.java
+++ b/backend/auth-api/src/test/java/com/jcluna/auth_api/security/RoleAccessControlTest.java
@@ -1,0 +1,110 @@
+package com.jcluna.auth_api.security;
+
+
+import com.jcluna.auth_api.model.User;
+import com.jcluna.auth_api.model.enums.Role;
+import com.jcluna.auth_api.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class RoleAccessControlTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private String userToken;
+    private String adminToken;
+    private String guestToken;
+
+    @BeforeEach
+    void setUp() {
+
+            userRepository.deleteAll();
+
+            User userUser = new User();
+            userUser.setEmail("user@test.com");
+            userUser.setUserName("user");
+            userUser.setPassword(passwordEncoder.encode("password"));
+            userUser.setRole(Role.ROLE_USER);
+            userRepository.save(userUser);
+
+            User adminUser = new User();
+            adminUser.setEmail("admin@test.com");
+            adminUser.setUserName("admin");
+            adminUser.setPassword(passwordEncoder.encode("password"));
+            adminUser.setRole(Role.ROLE_ADMIN);
+            userRepository.save(adminUser);
+
+            User guestUser = new User();
+            guestUser.setEmail("guest@test.com");
+            guestUser.setUserName("guest");
+            guestUser.setPassword(passwordEncoder.encode("password"));
+            guestUser.setRole(Role.ROLE_GUEST);
+            userRepository.save(guestUser);
+
+            userToken = jwtService.generateToken(userUser);
+            adminToken = jwtService.generateToken(adminUser);
+            guestToken = jwtService.generateToken(guestUser);
+    }
+
+
+    // Test 1
+    @Test
+    void guest_canAccess_publicEndpoints() throws Exception {
+        mockMvc.perform(get("/quotes")
+                        .header("Authorization", "Bearer " + guestToken))
+                .andExpect(status().isOk());
+    }
+
+
+    // Test 2
+    @Test
+    void guest_cannotAccess_protectedEndpoints() throws Exception {
+        mockMvc.perform(get("/quotes/me")
+                        .header("Authorization", "Bearer " + guestToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // Test 3
+    @Test
+    void user_canAccess_protectedEndpoints() throws Exception {
+        mockMvc.perform(get("/quotes/me")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk());
+    }
+
+    // Test 4
+    @Test
+    void admin_canAccess_protectedEndpoints() throws Exception {
+        mockMvc.perform(get("/quotes/me")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+    }
+
+    // Test 5
+    @Test
+    void noToken_cannotAccess_protectedEndpoints() throws Exception {
+        mockMvc.perform(get("/quotes/me"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
Add security integration tests covering JWT filter behavior and 
role-based access control at HTTP layer.

## Total: 8 tests passing 


## Why
Unit tests covered JWT logic in isolation (JwtServiceTest). 
These tests verify that the security layer behaves correctly 
end-to-end: filter chain active, real HTTP responses, H2 in-memory DB.

## Tests added
### JwtFilterSecurityTest
- Request without token → 401
- Request with malformed token → 401
- Request with expired token → 401

### RoleAccessControlTest
- GUEST can access public endpoints → 200
- GUEST cannot access protected endpoints → 403
- USER can access protected endpoints → 200
- ADMIN can access protected endpoints → 200
- No token cannot access protected endpoints → 401

## Bugs fixed
- `MalformedJwtException` unhandled in `JwtAuthFilter` → HTTP 500
- `ExpiredJwtException` unhandled in `JwtAuthFilter` → HTTP 500
- Fix: `sendError(401, "No autorizado")` — consistent with `authenticationEntryPoint`

## Security
- Prevents internal stack trace exposure on invalid tokens (OWASP)
- Validates Broken Access Control is correctly enforced by role

## Test approach
- `@SpringBootTest` + `MockMvc` — real security filter chain
- H2 in-memory DB — isolated environment
- No real secrets used

## Tests in this PR
- JwtFilterSecurityTest: 3 tests
- RoleAccessControlTest: 5 tests

## Project total: 45 tests passing (37 existing + 8 new)