### PR TITLE
fix: add admin user migration and replace hardcoded UUID in quotes

### DIFF
--- a/backend/auth-api/src/main/resources/db/migration/V10__fix_quotes_admin_uuid.sql
+++ b/backend/auth-api/src/main/resources/db/migration/V10__fix_quotes_admin_uuid.sql
@@ -1,0 +1,3 @@
+UPDATE quotes
+SET user_id = (SELECT id FROM users WHERE user_name = 'user_JonA')
+WHERE user_id IS NULL;

--- a/backend/auth-api/src/main/resources/db/migration/V9__create_admin_user.sql
+++ b/backend/auth-api/src/main/resources/db/migration/V9__create_admin_user.sql
@@ -1,0 +1,5 @@
+INSERT INTO users (id, user_name, email, password, role)
+SELECT gen_random_uuid(), 'user_JonA', 'useradmin@testadmin.com', '$2a$10$2o8uLG3YHtQJzHbVvqBoCuH9y9bP5E6acFtkJsxI2Rp5b.uyVtQP2', 'ROLE_ADMIN'
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE user_name = 'user_JonA'
+);


### PR DESCRIPTION
### Changes

- V9: adds admin user via Flyway migration using a pre-generated BCrypt hash. Uses WHERE NOT EXISTS to ensure idempotency in any environment.
- V10: replaces hardcoded admin UUID in quotes assignment with a subquery resolving the admin by username, making the migration reproducible in fresh database setups.

### Testing

- Flyway executed both migrations without errors
- Admin login verified via Postman
- Existing quotes maintain correct ownership