### PR TITLE
fix: rename userName to nickname to avoid collision with UserDetails getUsername

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/model/User.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/model/User.java
@@ -28,8 +28,8 @@ public class User implements UserDetails {   // Entity + Security Model through 
     private UUID id;
     @Column(unique = true, nullable = false)
     private String email;
-    @Column(unique = true, nullable = false)
-    private String userName;
+    @Column(name = "user_name", unique = true, nullable = false)
+    private String nickname;
     @Column(nullable = false)
     private String password;
 

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/AuthServiceImpl.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/AuthServiceImpl.java
@@ -38,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
 
         User newUser = new User();
         newUser.setEmail(request.getEmail());
-        newUser.setUserName(request.getUserName());
+        newUser.setNickname(request.getUserName());
 
         // Password hashed with BCrypt before persistence (OWASP A04:2025 - Cryptographic Failures)
         newUser.setPassword(passwordEncoder.encode(request.getPassword()));
@@ -69,6 +69,6 @@ public class AuthServiceImpl implements AuthService {
         String token = jwtService.generateToken(authenticatedUser);
 
 
-        return new AuthResponse(token, authenticatedUser.getUsername(), authenticatedUser.getEmail());
+        return new AuthResponse(token, authenticatedUser.getNickname(), authenticatedUser.getEmail());
     }
 }

--- a/backend/auth-api/src/test/java/com/jcluna/auth_api/security/RoleAccessControlTest.java
+++ b/backend/auth-api/src/test/java/com/jcluna/auth_api/security/RoleAccessControlTest.java
@@ -43,21 +43,21 @@ public class RoleAccessControlTest {
 
             User userUser = new User();
             userUser.setEmail("user@test.com");
-            userUser.setUserName("user");
+            userUser.setNickname("user");
             userUser.setPassword(passwordEncoder.encode("password"));
             userUser.setRole(Role.ROLE_USER);
             userRepository.save(userUser);
 
             User adminUser = new User();
             adminUser.setEmail("admin@test.com");
-            adminUser.setUserName("admin");
+            adminUser.setNickname("admin");
             adminUser.setPassword(passwordEncoder.encode("password"));
             adminUser.setRole(Role.ROLE_ADMIN);
             userRepository.save(adminUser);
 
             User guestUser = new User();
             guestUser.setEmail("guest@test.com");
-            guestUser.setUserName("guest");
+            guestUser.setNickname("guest");
             guestUser.setPassword(passwordEncoder.encode("password"));
             guestUser.setRole(Role.ROLE_GUEST);
             userRepository.save(guestUser);

--- a/backend/auth-api/src/test/java/com/jcluna/auth_api/service/AuthServiceImplTest.java
+++ b/backend/auth-api/src/test/java/com/jcluna/auth_api/service/AuthServiceImplTest.java
@@ -51,7 +51,7 @@ public class AuthServiceImplTest {
     void setUp() {
         testUser = new User();
         testUser.setEmail("test@test.com");
-        testUser.setUserName("testuser");
+        testUser.setNickname("testuser");
         testUser.setPassword("hashedPassword");
         testUser.setRole(Role.ROLE_USER);
 


### PR DESCRIPTION
The userName field in the User entity conflicted with getUsername() from UserDetails, which is mapped to email for Spring Security authentication. Lombok was not generating getUserName() due to the collision, leaving the field inaccessible and causing the login response to return the email in the username field.

### Changes

- Renamed userName to nickname in User entity
- Added @Column(name = "user_name") to preserve database column mapping
- Updated AuthServiceImpl to use getNickname() in the login response
- Updated tests to reflect the renamed field

### Testing

- Login returns correct nickname in response
- Existing tests updated and passing