### PR TITLE
chore: remove unused Quote import and optimize randomQuote with nativ…

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/repository/QuoteRepository.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/repository/QuoteRepository.java
@@ -20,7 +20,6 @@ public interface QuoteRepository extends JpaRepository<Quote, UUID> {
 
      List<Quote> findByUser(User user);
 
-
     //To verify ownership before delete
     Optional<Quote> findByIdAndUser(UUID id, User user);
 
@@ -34,4 +33,10 @@ public interface QuoteRepository extends JpaRepository<Quote, UUID> {
             countQuery = "SELECT count(*) FROM quotes WHERE unaccent(lower(text)) LIKE '%' || unaccent(lower(:text)) || '%'",
             nativeQuery = true)
     Page<Quote> findByTextContainingIgnoreCase(@Param("text") String text, Pageable pageable);
+
+    // Native query delegates random selection to the database, avoiding loading all quotes into memory
+    @Query(value = "SELECT * FROM quotes ORDER BY RANDOM() LIMIT 1", nativeQuery = true)
+    Optional<Quote> findRandomQuote();
+
+
 }

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/SignatureService.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/SignatureService.java
@@ -2,7 +2,6 @@ package com.jcluna.auth_api.service;
 
 import com.jcluna.auth_api.dto.SignatureRequest;
 import com.jcluna.auth_api.dto.SignatureResponse;
-import com.jcluna.auth_api.model.Quote;
 import com.jcluna.auth_api.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/QuoteServiceImpl.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/service/impl/QuoteServiceImpl.java
@@ -33,14 +33,13 @@ public class QuoteServiceImpl implements QuoteService {
 
     @Override
     public QuoteResponse getRandomQuote() {
-        List<Quote> quotes = quoteRepository.findAll();
-        if (quotes.isEmpty()) {
-            // Random needs at least one quote to work, unlike listings that can return empty.
-            // Empty DB is unexpected since quotes are preloaded by Flyway, so I warn.
-            log.warn("No quotes available to return a random quote");
-            throw new QuoteNotFoundException("No se encontró el recurso");
-        }
-        Quote random = quotes.get(new Random().nextInt(quotes.size()));
+        Quote random = quoteRepository.findRandomQuote()
+                .orElseThrow(() -> {
+                    // Random needs at least one quote to work, unlike listings that can return empty.
+                    // Empty DB is unexpected since quotes are preloaded by Flyway, so I warn.
+                    log.warn("No quotes available to return a random quote");
+                    return new QuoteNotFoundException("No se encontró el recurso");
+                });
         return quoteMapper.toResponse(random);
     }
 


### PR DESCRIPTION
### Changes

- Remove unused import in `SignatureService` `Quote` was imported but never used. Removed to keep the codebase clean.

- Optimize `randomQuote` with native database query. 
Previous implementation loaded all quotes into memory with findAll() and picked one randomly in Java. Replaced with a native query using `ORDER BY RANDOM() LIMIT 1`, delegating the random selection to the database.

This avoids unnecessary memory usage as the dataset grows and follows the principle of doing work at the database level when possible.

### Testing

Random quote endpoint verified via Postman
Existing behavior unchanged

