### PR TITLE
Fix/guest user email validation

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/RegisterRequest.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/dto/RegisterRequest.java
@@ -18,7 +18,10 @@ public class RegisterRequest {
 
 
     @NotBlank(message = "El email es obligatorio")
-    @Email(message = "Formato de email no válido")
+    @Email(
+            regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+            message = "Formato de email no válido"
+    )
     private String email;
 
 

--- a/backend/auth-api/src/main/resources/db/migration/V11__create_guest_user.sql
+++ b/backend/auth-api/src/main/resources/db/migration/V11__create_guest_user.sql
@@ -1,0 +1,5 @@
+INSERT INTO users (id, email, user_name, password, role)
+SELECT gen_random_uuid(), 'usertest@test.com', 'User_Test', '$2a$10$dC8goURROnpcReXXuRphkOo3ZD7fmVmNlm8CMFoPqDhvDKDe1fpHm', 'ROLE_GUEST'
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE email = 'usertest@test.com'
+);


### PR DESCRIPTION
### Changes
- **Guest user via Flyway migration (V11):** Added a demo guest user with ROLE_GUEST using the same idempotent pattern as the admin user (WHERE NOT EXISTS). Credentials are public by design — this is a demo account intended for portfolio reviewers to access the app without registering.

- **Email validation improvement:**  Added regexp to @Email annotation in RegisterRequest to enforce a valid TLD. Previous validation accepted formats like a@b or user@test. Now requires text@domain.tld with at least 2 characters after the last dot.

### Testing

V11 migration executed without errors
Guest user login verified via Postman
Email validation tested with valid and invalid formats