### PR TITLE
feat: add global CORS configuration

### DIFF
--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/AuthController.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/controller/AuthController.java
@@ -7,12 +7,10 @@ import com.jcluna.auth_api.dto.RegisterRequest;
 import com.jcluna.auth_api.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@CrossOrigin
 @RequestMapping("/auth")
 public class AuthController {
 

--- a/backend/auth-api/src/main/java/com/jcluna/auth_api/security/SecurityConfig.java
+++ b/backend/auth-api/src/main/java/com/jcluna/auth_api/security/SecurityConfig.java
@@ -17,6 +17,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -38,6 +41,16 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(request -> {
+                    CorsConfiguration config = new CorsConfiguration();
+                    config.setAllowedOrigins(List.of("http://localhost:5173"));
+                    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                    config.setAllowedHeaders(List.of("*"));
+                    config.setAllowCredentials(true);
+                    return config;
+                }))
+
+
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**","/error").permitAll()


### PR DESCRIPTION
Replaces the @CrossOrigin annotation on AuthController with a centralized CORS configuration in SecurityConfig, allowing requests from frontend.